### PR TITLE
Fix a slider bug when maxVal is too large.

### DIFF
--- a/nucular.go
+++ b/nucular.go
@@ -2083,8 +2083,9 @@ func doSlider(win *Window, bounds rect.Rect, minval float64, val float64, maxval
 	cursor_offset = (slider_value - minval) / step
 
 	cursor.H = bounds.H
-	cursor.W = bounds.W / (slider_steps + 1)
-	cursor.X = bounds.X + int((float64(cursor.W) * cursor_offset))
+	tempW := float64(bounds.W) / float64(slider_steps+1)
+	cursor.W = int(tempW)
+	cursor.X = bounds.X + int((tempW * cursor_offset))
 	cursor.Y = bounds.Y
 
 	out := &win.widgets


### PR DESCRIPTION
If the max value for the slider is too large, there will be a bug, the cursor won't move.