### PR TITLE
Add support for password widget

### DIFF
--- a/text.go
+++ b/text.go
@@ -217,6 +217,7 @@ const (
 	EditNeverInsertMode
 	EditFocusFollowsMouse
 	EditNoContextMenu
+	EditPassword
 
 	EditSimple = EditAlwaysInsertMode
 	EditField  = EditSelectable | EditClipboard | EditSigEnter
@@ -1559,6 +1560,10 @@ func (d *drawableTextEditor) Draw(z *nstyle.Style, out *command.Buffer) {
 		background_color = color.RGBA{0, 0, 0, 0}
 	} else {
 		background_color = background.Data.Color
+	}
+
+	if edit.Flags&EditPassword != 0 {
+		text_color = color.RGBA{0, 0, 0, 1}
 	}
 
 	startPos := image.Point{area.X - edit.Scrollbar.X, area.Y - edit.Scrollbar.Y}

--- a/text.go
+++ b/text.go
@@ -167,8 +167,7 @@ type TextEditor struct {
 	clickCount      int
 	trueSelectStart int
 
-	needle   []rune
-	password []rune
+	needle []rune
 }
 
 type drawchunk struct {
@@ -192,9 +191,6 @@ func (ed *TextEditor) init(win *Window) {
 		if ed.win == nil {
 			if ed.Buffer == nil {
 				ed.Buffer = []rune{}
-			}
-			if ed.password == nil {
-				ed.password = []rune{}
 			}
 			ed.Filter = nil
 			ed.Cursor = 0
@@ -221,7 +217,6 @@ const (
 	EditNeverInsertMode
 	EditFocusFollowsMouse
 	EditNoContextMenu
-	EditPassword
 
 	EditSimple = EditAlwaysInsertMode
 	EditField  = EditSelectable | EditClipboard | EditSigEnter
@@ -460,9 +455,7 @@ func (state *TextEditor) clamp() {
 func (edit *TextEditor) Delete(where int, len int) {
 	/* delete characters while updating undo */
 	edit.makeundoDelete(where, len)
-	if edit.Flags&EditPassword != 0 {
-		edit.password = strDeleteText(edit.password, where, len)
-	}
+
 	edit.Buffer = strDeleteText(edit.Buffer, where, len)
 	edit.HasPreferredX = false
 }
@@ -652,12 +645,6 @@ func (edit *TextEditor) Paste(ctext string) {
 
 	text := []rune(ctext)
 
-	if edit.Flags&EditPassword != 0 {
-		edit.password = strInsertText(edit.password, edit.Cursor, text)
-		for i := range text {
-			text[i] = '*'
-		}
-	}
 	edit.Buffer = strInsertText(edit.Buffer, edit.Cursor, text)
 
 	edit.makeundoInsert(edit.Cursor, len(text))
@@ -681,30 +668,19 @@ func (edit *TextEditor) Text(text []rune) {
 			continue
 		}
 
-		if edit.Flags&EditPassword != 0 {
-			edit.DeleteSelection() /* implicitly clamps */
-			edit.password = strInsertText(edit.password, edit.Cursor, text[i:i+1])
-			edit.Buffer = strInsertText(edit.Buffer, edit.Cursor, []rune{'*'})
-			edit.makeundoInsert(edit.Cursor, 1)
-			edit.Cursor++
-			edit.HasPreferredX = false
-			continue
-		}
-
 		if edit.InsertMode && !edit.hasSelection() && edit.Cursor < len(edit.Buffer) {
 			edit.makeundoReplace(edit.Cursor, 1, 1)
 			edit.Buffer = strDeleteText(edit.Buffer, edit.Cursor, 1)
 			edit.Buffer = strInsertText(edit.Buffer, edit.Cursor, text[i:i+1])
 			edit.Cursor++
 			edit.HasPreferredX = false
-			continue
+		} else {
+			edit.DeleteSelection() /* implicitly clamps */
+			edit.Buffer = strInsertText(edit.Buffer, edit.Cursor, text[i:i+1])
+			edit.makeundoInsert(edit.Cursor, 1)
+			edit.Cursor++
+			edit.HasPreferredX = false
 		}
-
-		edit.DeleteSelection() /* implicitly clamps */
-		edit.Buffer = strInsertText(edit.Buffer, edit.Cursor, text[i:i+1])
-		edit.makeundoInsert(edit.Cursor, 1)
-		edit.Cursor++
-		edit.HasPreferredX = false
 	}
 }
 
@@ -1023,12 +999,6 @@ func texteditCreateundo(state *textUndoState, pos int, insert_len int, delete_le
 }
 
 func (edit *TextEditor) DoUndo() {
-
-	// do not allow undo on password field
-	if edit.Flags&EditPassword != 0 {
-		return
-	}
-
 	var s *textUndoState = &edit.Undo
 	var u textUndoRecord
 	var r *textUndoRecord
@@ -1065,12 +1035,6 @@ func (edit *TextEditor) DoUndo() {
 }
 
 func (edit *TextEditor) DoRedo() {
-
-	// do not allow redo on password field
-	if edit.Flags&EditPassword != 0 {
-		return
-	}
-
 	var s *textUndoState = &edit.Undo
 	var u *textUndoRecord
 	var r textUndoRecord
@@ -1829,22 +1793,4 @@ func (edit *TextEditor) Edit(win *Window) EditEvents {
 
 	ev := edit.doEdit(bounds, &style.Edit, in, cut, copy, paste)
 	return ev
-}
-
-func (edit *TextEditor) Content() []rune {
-	if edit.Flags&EditPassword != 0 {
-		return edit.password
-	}
-	return edit.Buffer
-}
-
-func NewPasswordWidget(value []rune) *TextEditor {
-	p := &TextEditor{password: value}
-	p.Buffer = make([]rune, len(value))
-	for i := range value {
-		p.Buffer[i] = '*'
-	}
-
-	p.Flags = EditField | EditPassword
-	return p
 }


### PR DESCRIPTION
This PR extends the text editor adding support for contents are visibly obfuscated like passwords.