### PR TITLE
fix crash on nil

### DIFF
--- a/nucular.go
+++ b/nucular.go
@@ -2489,7 +2489,7 @@ func (win *Window) doProperty(property rect.Rect, name string, text string, filt
 
 	ws := win.widgets.PrevState(property)
 	oldws := ws
-	if ws == nstyle.WidgetStateActive {
+	if ws == nstyle.WidgetStateActive && win.editor != nil {
 		ed = win.editor
 	} else {
 		ed = &TextEditor{}


### PR DESCRIPTION
Rapid clicking between properties under Widgets>Basic in the demo app crashes the app on nil dereference on line 2500 because `ed` is `nil`.