### PR TITLE
Remove unused function

### DIFF
--- a/_examples/demo/calculator.go
+++ b/_examples/demo/calculator.go
@@ -25,9 +25,6 @@ var calcBtns = []string{
 	"C", "0", "=", "/",
 }
 
-func digitfn(c *calcDemo, lbl string) {
-}
-
 func (c *calcDemo) calculatorDemo(w *nucular.Window) {
 	w.Row(35).Dynamic(1)
 	c.editor.Flags = nucular.EditSimple


### PR DESCRIPTION
Function `digitfn` is not used in this example  

https://github.com/aarzilli/nucular/blob/3e3c504fb81cb11ae34797e40e4757b7431f912e/_examples/demo/calculator.go#L28-L29