### PR TITLE
Exposes the ability to query/force the root window focus #82

### DIFF
--- a/nucular.go
+++ b/nucular.go
@@ -203,6 +203,16 @@ func (win *Window) Title() string {
 	return win.title
 }
 
+// RootFocused returns true if the MasterWindow root is in focus
+func (win *Window) RootFocused() bool {
+	return win.ctx.rootWindowFocus
+}
+
+// RootFocused requests the MasterWindow root to be focused.
+func (win *Window) FocusRoot() {
+	win.ctx.rootWindowFocus = true
+}
+
 // SetTitle cannot be used to change the title of the Root window, only sub-windows and the gio backend.
 func (win *Window) SetTitle(s string) {
 	if win.idx == 0 && win.title != s {


### PR DESCRIPTION
Working on trying to get to the bottom of the root focus issue, and figured exposing these features via nucular.Window might be a good idea (but always happy to defer to your guidance if not!)  😅 