### PR TITLE
Fixes FIPS-140 Builds

### DIFF
--- a/font/font_shiny.go
+++ b/font/font_shiny.go
@@ -1,7 +1,7 @@
 package font
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"sync"
 
 	"golang.org/x/image/font"
@@ -15,11 +15,11 @@ type Face struct {
 }
 
 var fontsMu sync.Mutex
-var fontsMap = map[[md5.Size]byte]*truetype.Font{}
+var fontsMap = map[[sha256.Size]byte]*truetype.Font{}
 
 // NewFace returns a new face by parsing the ttf font.
 func NewFace(ttf []byte, size int) (Face, error) {
-	key := md5.Sum(ttf)
+	key := sha256.Sum256(ttf)
 	fontsMu.Lock()
 	defer fontsMu.Unlock()
 


### PR DESCRIPTION
In Golang 1.24, a new FIPS 140-2 compliant crypto module is optionally enabled with a new `GODEBUG=fips140` flag.  When operating in `fips140=only` mode, the system will panic on any use of noncompliant algorithms.  Unfortunately, this causes apps using nucular to crash when launching due to the md5 hash used to cache fonts in font_shiny.go.  The crash looks like:

```
panic: crypto/md5: use of MD5 is not allowed in FIPS 140-only mode

goroutine 1 [running]:
crypto/md5.(*digest).checkSum(0x0?)
        /home/brian/.go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/md5/md5.go:162 +0x105
crypto/md5.Sum({0x1aaeec0?, 0xf6d02b?, 0x3?})
        /home/brian/.go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/md5/md5.go:194 +0x98
github.com/aarzilli/nucular/font.NewFace({0x1aaeec0, 0x1135c, 0x1135c}, 0x14)
        /home/brian/.go/pkg/mod/github.com/aarzilli/nucular@v0.0.0-20250326143821-b95de069f8be/font/font_shiny.go:22 +0x5d
(calling function)
```

This PR fixes that by switching the hash key from md5 to sha256.